### PR TITLE
fix: 無効リンクを変更

### DIFF
--- a/books/conform-guide/accessibility.md
+++ b/books/conform-guide/accessibility.md
@@ -123,12 +123,11 @@ export default function Example() {
 
 > 注意: これらすべてのヘルパーはネイティブ HTML 要素用に設計されています。 react-aria-components や Radix UI のようなカスタム UI コンポーネントを使用している場合、それらの API を通じて既に属性が設定されている可能性があるため、これらのヘルパーが不要になるかもしれません。
 
-- [getFormProps](api-react-getformprops.md)
-- [getFieldsetProps](api-react-getfieldsetprops.md)
-- [getInputProps](api-react-getinputprops.md)
-- [getSelectProps](api-react-getselectprops.md)
-- [getTextareaProps](api-react-gettextareaprops.md)
-- [getCollectionProps](api-react-getbuttonprops.md)
+- [getFormProps](./api-react-getformprops)
+- [getFieldsetProps](./api-react-getfieldsetprops)
+- [getInputProps](./api-react-getinputprops)
+- [getSelectProps](./api-react-getselectprops)
+- [getTextareaProps](./api-react-gettextareaprops)
 
 以下は、手動設定と比較した場合の例です。ヘルパーについて詳しく知りたい場合は、上記リンクの対応するドキュメントを確認してください。
 

--- a/books/conform-guide/api-react-formprovider.md
+++ b/books/conform-guide/api-react-formprovider.md
@@ -18,7 +18,7 @@ export default function SomeParent() {
 
 ### `context`
 
-フォームコンテキストです。これは [useForm](./useForm.md) で作成され、 `form.context` を通じてアクセスできます。
+フォームコンテキストです。これは [useForm](./useForm) で作成され、 `form.context` を通じてアクセスできます。
 
 ## Tips
 

--- a/books/conform-guide/api-react-formprovider.md
+++ b/books/conform-guide/api-react-formprovider.md
@@ -2,7 +2,7 @@
 title: "@conform-to/react: FormProvider"
 ---
 
-フォームコンテキストのための [Context Provider](https://react.dev/reference/react/createContext#provider) をレンダリングする React コンポーネントです。 [useField](api-react-usefield.md) や [useFormMetadata](api-react-useformmetadata.md) フックを使用したい場合には必須です。
+フォームコンテキストのための [Context Provider](https://react.dev/reference/react/createContext#provider) をレンダリングする React コンポーネントです。 [useField](./api-react-usefield) や [useFormMetadata](./api-react-useformmetadata) フックを使用したい場合には必須です。
 
 ```tsx
 import { FormProvider, useForm } from "@conform-to/react";

--- a/books/conform-guide/api-react-usefield.md
+++ b/books/conform-guide/api-react-usefield.md
@@ -2,7 +2,7 @@
 title: "@conform-to/react: useField"
 ---
 
-[FormProvider](api-react-formprovider.md) に設定されたコンテキストを購読することで、フィールドメタデータを返す React フックです。これは **最も近い** [FormProvider](api-react-formprovider.md) に基づいています。
+[FormProvider](./api-react-formprovider) に設定されたコンテキストを購読することで、フィールドメタデータを返す React フックです。これは **最も近い** [FormProvider](./api-react-formprovider) に基づいています。
 
 ```tsx
 const [meta, form] = useField(name, options);
@@ -16,17 +16,17 @@ const [meta, form] = useField(name, options);
 
 ### `options`
 
-現時点での **オプション** は 1 つだけです。入れ子になったフォームコンテキストがあり、最も近い [FormProvider](api-react-formprovider.md) からではないフィールドにアクセスしたい場合は、 `formId` を渡して、正しいフィールドメタデータが返されるようにすることができます。
+現時点での **オプション** は 1 つだけです。入れ子になったフォームコンテキストがあり、最も近い [FormProvider](./api-react-formprovider) からではないフィールドにアクセスしたい場合は、 `formId` を渡して、正しいフィールドメタデータが返されるようにすることができます。
 
 ## 戻り値
 
 ### `meta`
 
-フィールドメタデータです。これは、 [useForm](api-react-useform.md) フックを使用した場合の `fields.fieldName` に相当します。
+フィールドメタデータです。これは、 [useForm](./api-react-useform) フックを使用した場合の `fields.fieldName` に相当します。
 
 ### `form`
 
-フォームメタデータです。これは、 [useForm](api-react-useform.md) または [useFormMetadata](api-react-useformmetadata.md) フックによって返されるオブジェクトと同じものです。
+フォームメタデータです。これは、 [useForm](./api-react-useform) または [useFormMetadata](./api-react-useformmetadata) フックによって返されるオブジェクトと同じものです。
 
 ## Tips
 

--- a/books/conform-guide/api-react-useformmetadata.md
+++ b/books/conform-guide/api-react-useformmetadata.md
@@ -2,7 +2,7 @@
 title: "@conform-to/react: useFormMetadata"
 ---
 
-[FormProvider](api-react-formprovider.md) に設定されたコンテキストを購読することで、フォームのメタデータを返す React フックです。
+[FormProvider](./api-react-formprovider) に設定されたコンテキストを購読することで、フォームのメタデータを返す React フックです。
 
 ```tsx
 const form = useFormMetadata(formId);
@@ -18,7 +18,7 @@ const form = useFormMetadata(formId);
 
 ### `form`
 
-フォームメタデータです。これは、 [useForm](api-react-useform.md) フックによって返されるオブジェクトと同じです。
+フォームメタデータです。これは、 [useForm](./api-react-useform) フックによって返されるオブジェクトと同じです。
 
 ## Tips
 

--- a/books/conform-guide/complex-structures.md
+++ b/books/conform-guide/complex-structures.md
@@ -39,7 +39,7 @@ function Example() {
 
 ## 配列
 
-フィールドのリストを設定する必要がある場合は、親フィールドのメタデータから `getFieldList()` メソッドを呼び出して、名前が自動的に推測される各アイテムフィールドにアクセスできます。リスト内のアイテムを変更したい場合は、 [Intent button](./intent-button.md#insert-remove-and-reorder-intents) ページで説明されているように、 `insert` 、 `remove` 、 `reorder` のインテントも使用できます。
+フィールドのリストを設定する必要がある場合は、親フィールドのメタデータから `getFieldList()` メソッドを呼び出して、名前が自動的に推測される各アイテムフィールドにアクセスできます。リスト内のアイテムを変更したい場合は、 [Intent button](./intent-button#フォームのコントロール) ページで説明されているように、 `insert` 、 `remove` 、 `reorder` のインテントも使用できます。
 
 ```tsx
 import { useForm } from "@conform-to/react";

--- a/books/conform-guide/integration-ui-libraries.md
+++ b/books/conform-guide/integration-ui-libraries.md
@@ -62,9 +62,9 @@ function Example() {
 
 ## `useInputControl` を使用してカスタム入力コンポーネントを強化する
 
-この問題を解決するために、 Conform は [useInputControl](api-react-useinputcontrol.md) というフックを提供しています。これにより、必要なときにフォームイベントを発行するようにカスタム入力を強化できます。このフックは以下のプロパティを持つコントロールオブジェクトを返します:
+この問題を解決するために、 Conform は [useInputControl](./api-react-useinputcontrol) というフックを提供しています。これにより、必要なときにフォームイベントを発行するようにカスタム入力を強化できます。このフックは以下のプロパティを持つコントロールオブジェクトを返します:
 
-- `value`: フォームの[リセットおよび更新のインテント](intent-button.md#reset-and-update-intent)に対応した、入力の現在の値
+- `value`: フォームの[リセットおよび更新のインテント](./intent-button#reset-および-update-インテント)に対応した、入力の現在の値
 - `change`: 現在の値を更新し、`change` および `input` イベントの両方を発行するための関数
 - `focus`: `focus` および `focusin` イベントを発行するための関数
 - `blur`: `blur` および`focusout` イベントを発行するための関数
@@ -155,7 +155,7 @@ function Example() {
 
 ## フォームコンテキストでシンプルに
 
-[useField](api-react-usefield.md) フックを [FormProvider](api-react-formprovider.md) と共に使用することで、ラッパーコンポーネントをさらにシンプルにすることもできます。
+[useField](./api-react-usefield) フックを [FormProvider](./api-react-formprovider) と共に使用することで、ラッパーコンポーネントをさらにシンプルにすることもできます。
 
 ```tsx
 import {

--- a/books/conform-guide/intent-button.md
+++ b/books/conform-guide/intent-button.md
@@ -130,7 +130,7 @@ export default function Tasks() {
 }
 ```
 
-両方のインテントを使用するには、フィールドメタデータから **key** を使って入力を設定する必要があります。 Conform はこのキーに依存して、更新された initialValue で input を再マウントするための React への通知を行います。唯一の例外は、 [useInputControl](api-react-useinputcontrol.md) フックを使用して制御された入力を設定している場合で、 key が変更されると値がリセットされます。
+両方のインテントを使用するには、フィールドメタデータから **key** を使って入力を設定する必要があります。 Conform はこのキーに依存して、更新された initialValue で input を再マウントするための React への通知を行います。唯一の例外は、 [useInputControl](./api-react-useinputcontrol) フックを使用して制御された入力を設定している場合で、 key が変更されると値がリセットされます。
 
 ### insert、remove、および reorder (並び替え) インテント
 

--- a/books/conform-guide/tutorial.md
+++ b/books/conform-guide/tutorial.md
@@ -244,7 +244,7 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 ```
 
-これで、 [useForm](api-react-useform.md) フックを使って、すべてのフォームメタデータを管理できます。また、 `getZodConstraint()` ヘルパーを使用して、 zod スキーマからバリデーション属性を導出します。
+これで、 [useForm](./api-react-useform) フックを使って、すべてのフォームメタデータを管理できます。また、 `getZodConstraint()` ヘルパーを使用して、 zod スキーマからバリデーション属性を導出します。
 
 ```tsx
 import { useForm } from '@conform-to/react';
@@ -415,7 +415,7 @@ export default function ContactUs() {
 
 ## ボイラープレートの削除
 
-Conform がすべての ID とバリデーション属性を管理してくれるのは素晴らしいことです。しかし、フォームとフィールドを設定するのにはまだ多くの作業が必要です。ネイティブ入力を扱っている場合は、 [getFormProps](api-react-getformprops.md) や [getInputProps](api-react-getinputprops.md) のようなヘルパーを使用してボイラープレートを最小限に抑えることができます。
+Conform がすべての ID とバリデーション属性を管理してくれるのは素晴らしいことです。しかし、フォームとフィールドを設定するのにはまだ多くの作業が必要です。ネイティブ入力を扱っている場合は、 [getFormProps](./api-react-getformprops) や [getInputProps](./api-react-getinputprops) のようなヘルパーを使用してボイラープレートを最小限に抑えることができます。
 
 ```tsx
 import {

--- a/books/conform-guide/upgrading-v1.md
+++ b/books/conform-guide/upgrading-v1.md
@@ -129,7 +129,7 @@ function Example() {
 
 #### `@conform-to/yup`
 
-- `parse` -&gt; [parseWithYup](./api/yup/parseWithYup.md)
+- `parse` -&gt; [parseWithYup](./api/yup/parseWithYup)
 - `getFieldsetConstraint` -&gt; [getYupConstraint](api-yup-getyupconstraint.md)
 
 ## 送信処理の改善

--- a/books/conform-guide/upgrading-v1.md
+++ b/books/conform-guide/upgrading-v1.md
@@ -12,16 +12,16 @@ Conform は現在、 React 18 以降を要求します。もし古いバージ�
 
 まず、すべてのヘルパーが改名され、個別にインポートできるようになりました:
 
-- `conform.input` -&gt; [getInputProps](api-react-getinputprops.md)
-- `conform.select` -&gt; [getSelectProps](api-react-getselectprops.md)
-- `conform.textarea` -&gt; [getTextareaProps](api-react-gettextareaprops.md)
-- `conform.fieldset` -&gt; [getFieldsetProps](api-react-getfieldsetprops.md)
-- `conform.collection` -&gt; [getCollectionProps](api-react-getcollectionprops.md)
+- `conform.input` -&gt; [getInputProps](./api-react-getinputprops)
+- `conform.select` -&gt; [getSelectProps](./api-react-getselectprops)
+- `conform.textarea` -&gt; [getTextareaProps](./api-react-gettextareaprops)
+- `conform.fieldset` -&gt; [getFieldsetProps](./api-react-getfieldsetprops)
+- `conform.collection` -&gt; [getCollectionProps](./api-react-getcollectionprops)
 
 以前 `conform.VALIDATION_UNDEFINED` および `conform.VALIDATION_SKIPPED` を使用していた場合、それらは zod インテグレーション (`@conform-to/zod`) に移されました。
 
-- `conform.VALIDATION_SKIPPED` -&gt; [conformZodMessage.VALIDATION_SKIPPED](api-zod-conformzodmessage.md#conformzodmessagevalidation_skipped)
-- `conform.VALIDATION_UNDEFINED` -&gt; [conformZodMessage.VALIDATION_UNDEFINED](api-zod-conformzodmessage.md#conformzodmessagevalidation_undefined)
+- `conform.VALIDATION_SKIPPED` -&gt; [conformZodMessage.VALIDATION_SKIPPED](./api-zod-conformzodmessage#conformzodmessage.validation_skipped)
+- `conform.VALIDATION_UNDEFINED` -&gt; [conformZodMessage.VALIDATION_UNDEFINED](./api-zod-conformzodmessage#conformzodmessage.validation_undefined)
 
 `conform.INTENT` はもはやエクスポートされていないことに注意してください。インテントボタンを設定する必要がある場合は、より良い型安全性のために zod の [z.discriminatedUnion()](https://zod.dev/?id=discriminated-unions) と組み合わせて、それを **intent** （または好みの何か）と名付けることができます。
 
@@ -45,7 +45,7 @@ Conform は現在、 React 18 以降を要求します。もし古いバージ�
 
 ## フォーム設定の変更点
 
-まず、`form.props` が削除されました。代わりに [getFormProps()](api-react-getformprops.md) ヘルパーを使用できます。
+まず、`form.props` が削除されました。代わりに [getFormProps()](./api-react-getformprops) ヘルパーを使用できます。
 
 ```tsx
 import { useForm, getFormProps } from "@conform-to/react";
@@ -124,13 +124,13 @@ function Example() {
 
 #### `@conform-to/zod`
 
-- `parse` -&gt; [parseWithZod](api-zod-parsewithzod.md)
-- `getFieldsetConstraint` -&gt; [getZodConstraint](api-zod-getzodconstraint.md)
+- `parse` -&gt; [parseWithZod](./api-zod-parsewithzod)
+- `getFieldsetConstraint` -&gt; [getZodConstraint](./api-zod-getzodconstraint)
 
 #### `@conform-to/yup`
 
-- `parse` -&gt; [parseWithYup](./api/yup/parseWithYup)
-- `getFieldsetConstraint` -&gt; [getYupConstraint](api-yup-getyupconstraint.md)
+- `parse` -&gt; [parseWithYup](./api-yup-parsewithyup)
+- `getFieldsetConstraint` -&gt; [getYupConstraint](./api-yup-getyupconstraint)
 
 ## 送信処理の改善
 
@@ -187,7 +187,7 @@ export default function Example() {
 
 ## `useInputControl` フックを使用したインテグレーションがシンプルに
 
-`useInputEvent` フックは、いくつかの新機能を備えた [useInputControl](api-react-useinputcontrol.md) フックに置き換えられました。
+`useInputEvent` フックは、いくつかの新機能を備えた [useInputControl](./api-react-useinputcontrol) フックに置き換えられました。
 
 - もはや input 要素の ref を提供する必要はありません。 DOM から入力要素を探し出し、見つからない場合は自動で挿入します。
 


### PR DESCRIPTION
https://github.com/edmundhung/conform をそのまま引っ張ってきている影響かと思いますが、zennの本のページURLに`.md`がないのでリンク切れになってしまっています。
これを修正するPRです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated reference links in guides by removing file extensions for a clearer and more consistent presentation.
  - Adjusted navigation anchors in sections to improve user guidance and document flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->